### PR TITLE
ENH: Use Beam Drop Suspenders

### DIFF
--- a/run_skywalker_template.ipynb
+++ b/run_skywalker_template.ipynb
@@ -64,9 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "\"\"\"\n",
@@ -84,7 +82,7 @@
     "logging.basicConfig(level=log_level, format='%(name)s - %(message)s')\n",
     "\n",
     "from pswalker.examples  import patch_pims\n",
-    "from pswalker.skywalker import skywalker\n",
+    "from pswalker.skywalker import skywalker, lcls_RE\n",
     "from pswalker.config import homs_system\n",
     "from pswalker.plans import walk_to_pixel\n",
     "from pswalker.watcher import Watcher\n",
@@ -167,13 +165,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Create RunEngine\n",
-    "RE = RunEngine({})\n",
+    "RE = lcls_RE()\n",
     "RE.record_interruptions = True\n",
     "#Subscribe a Watcher instance\n",
     "watcher = Watcher()\n",
@@ -184,9 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "RE(plan)"
@@ -195,9 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "#Print Run Statistics\n",
@@ -234,7 +226,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Let's start using suspenders. The lcls_RE macro in pswalker.skywalker now creates a run engine with beam drop suspenders, so let's use that instead of starting from a blank run engine. Updated the template file accordingly.